### PR TITLE
Erste Version vom Remote-Screen implementiert

### DIFF
--- a/lib/models/remote_control/command.dart
+++ b/lib/models/remote_control/command.dart
@@ -12,8 +12,10 @@ class Command {
     String caption;
 
     /// Ctor for Commands
-    Command(String msg) {
+    Command(String msg, String caption, int profileId) {
         this.commandMessage = msg;
+        this.caption = caption;
+        this.profileId = profileId;
     }
 
     /// Converts data from Database into Command.
@@ -28,11 +30,9 @@ class Command {
 
     /// Constructor for Commands by the Database.
     static Command _fromDatabase(int id, int profileId, String commandMessage, String caption) {
-        Command cmd = new Command(commandMessage);
+        Command cmd = new Command(commandMessage, caption, profileId);
 
         cmd.id = id;
-        cmd.profileId = profileId;
-        cmd.caption = caption;
 
         return cmd;
     }

--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -55,8 +55,7 @@ class _DashboardState extends State<DashboardScreen> {
         });
     }
 
-    RefreshController _refreshController =
-    RefreshController(initialRefresh: false);
+    RefreshController _refreshController = RefreshController(initialRefresh: false);
 
     void _onRefresh() async{
         // monitor network fetch

--- a/lib/screens/remote_control/remote_control_screen.dart
+++ b/lib/screens/remote_control/remote_control_screen.dart
@@ -42,12 +42,9 @@ class _RemoteControlState extends State<RemoteControlScreen> {
     }
 
     void _onPress(Command cmd) async {
-        Profile server;
-        this.profilesFuture.then((value) => {
-           server = value
-        });
-        
-        RemoteService service = new RemoteService(server);
+        List<Profile> servers = await DatabaseService.db.getProfiles();
+        Profile server = await DatabaseService.db.getProfileById(servers[0].id);
+        var service = new RemoteService(server);
         service.execute(cmd);
     }
 

--- a/lib/screens/remote_control/remote_control_screen.dart
+++ b/lib/screens/remote_control/remote_control_screen.dart
@@ -4,6 +4,7 @@ import 'package:glutter/models/remote_control/command.dart';
 import 'package:glutter/services/remote_control/remote_service.dart';
 import 'package:glutter/services/shared/database_service.dart';
 import 'package:glutter/models/shared/profile.dart';
+import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 class RemoteControlScreen extends StatefulWidget {
     RemoteControlScreen({Key key, this.title: "Remote Control"}) : super(key: key);
@@ -16,10 +17,38 @@ class RemoteControlScreen extends StatefulWidget {
 }
 
 class _RemoteControlState extends State<RemoteControlScreen> {
+    Future commandsFuture;
+    Future profilesFuture;
 
     @override
     void initState() {
+        this.profilesFuture = DatabaseService.db.getProfiles();
+        this.commandsFuture = DatabaseService.db.getCommands();
         super.initState();
+    }
+
+    RefreshController _refreshController = RefreshController(initialRefresh: false);
+
+    void _onRefresh() async{
+        // monitor network fetch
+        await Future.delayed(Duration(milliseconds: 500));
+
+        this.setState(() {
+            this.commandsFuture = DatabaseService.db.getCommands();
+        });
+
+        // if failed,use refreshFailed()
+        _refreshController.refreshCompleted();
+    }
+
+    void _onPress(Command cmd) async {
+        Profile server;
+        this.profilesFuture.then((value) => {
+           server = value
+        });
+        
+        RemoteService service = new RemoteService(server);
+        service.execute(cmd);
     }
 
     @override
@@ -30,21 +59,76 @@ class _RemoteControlState extends State<RemoteControlScreen> {
                 title: Text(widget.title),
             ),
             drawer: AppDrawer(),
-            body:
-                Center(child:
-                    Text("Coming soon™")
-                ),
+            body: SmartRefresher(
+                enablePullDown: true,
+                enablePullUp: false,
+                header: ClassicHeader(),
+                controller: _refreshController,
+                onRefresh: _onRefresh,
+                child: SingleChildScrollView(
+                    child: Column(
+                        mainAxisSize: MainAxisSize.max,
+                        children: <Widget>[
+                            FutureBuilder(
+                                future: commandsFuture,
+                                builder: (BuildContext context, AsyncSnapshot snapshot) {
+                                    switch (snapshot.connectionState) {
+                                        case ConnectionState.active:
+                                        case ConnectionState.waiting:
+                                            return Container(
+                                                child: new CircularProgressIndicator(),
+                                                alignment: Alignment(
+                                                    0.0, 0.0
+                                                )
+                                            );
+                                        case ConnectionState.done:
+                                            if (snapshot.data != null) {
+                                                return new Column (
+                                                    mainAxisSize: MainAxisSize.max,
+                                                    children: List.generate(snapshot.data.length, (i) {
+                                                        return Card(
+                                                            child: Column(
+                                                                mainAxisSize: MainAxisSize.max,
+                                                                children: <Widget>[
+                                                                    ListTile(
+                                                                        leading: Icon(Icons.comment),
+                                                                        title: Text(snapshot.data[i].caption)
+                                                                    ),
+                                                                    Text(snapshot.data[i].commandMessage),
+                                                                    Padding(
+                                                                        padding: EdgeInsets.fromLTRB(0, 20, 0, 0)
+                                                                    ),
+                                                                    RaisedButton(
+                                                                        child: Text("Execute"),
+                                                                        onPressed: () {
+                                                                            _onPress(snapshot.data[i]);
+                                                                        },
+                                                                    ),
+                                                                    Padding(
+                                                                        padding: EdgeInsets.all(10),
+                                                                    )
+                                                                ],
+                                                            ),
+                                                        );
+                                                    })
+                                                );
+                                            }
+                                            return null;
+                                        default:
+                                            return Text("default");
+                                    }
+                                },
+                            )
+                        ]
+                    ),
+                )
+            ),
             floatingActionButton: FloatingActionButton(
+                child: Icon(Icons.add),
                 onPressed: () async {
-                    Command cmd = new Command("glances -w");
-
-                    List<Profile> servers = await DatabaseService.db.getProfiles();
-                    Profile server = await DatabaseService.db.getProfileById(servers.first.id);
-
-                    RemoteService service = new RemoteService(server);
-                    var res = await service.execute(cmd);
-                    print(res);
-                },
+                    Command cmd = new Command("glances -w", "Test for Glances", 1);
+                    await DatabaseService.db.insertCommand(cmd);
+                }
             ),
         );
     }

--- a/test/remote_service_test.dart
+++ b/test/remote_service_test.dart
@@ -19,7 +19,7 @@ void main() {
 
         /// Tests the correct functionality of getting the CPU-Values from the GlancesService.
         test('RemoteService ExecuteCommand', () async {
-            Command cmd = new Command("sudo service apache2 stop");
+            Command cmd = new Command("sudo service apache2 stop", "Test", 0);
             var result = await remoteService.execute(cmd);
             print(result);
         });


### PR DESCRIPTION
SSH-Befehle können angezeigt und ausgeführt werden.

Es fehlt noch:
- Screen zum Anlegen eines Commands
- Auswahl des Servers, für den ein Befehl ausgeführt werden soll. Aktuell wird es nur gegen den ersten Server in der Datenbank ausgeführt. 

ABER: Das Ausführen der SSH-Befehle funktioniert 🥇 