### PR TITLE
SSH-Form ergänzt (Command anlegen), Änderungen am RemoteControl-Screen

### DIFF
--- a/lib/screens/remote_control/command_create_screen.dart
+++ b/lib/screens/remote_control/command_create_screen.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:glutter/models/remote_control/command.dart';
+import 'package:glutter/screens/remote_control/widgets/command_form_widgets.dart';
+import 'package:glutter/services/shared/database_service.dart';
+import 'package:glutter/services/shared/preferences_service.dart';
+import 'package:glutter/utils/utils.dart';
+import 'package:glutter/widgets/dialogs.dart';
+
+class CommandCreateScreen extends StatefulWidget {
+  CommandCreateScreen({Key key, this.title: "Create new Command"}) : super(key: key);
+
+  static const String routeName = '/remote-control/create';
+  final String title;
+
+  @override
+  _CommandCreateState createState() => _CommandCreateState();
+}
+
+class _CommandCreateState extends State<CommandCreateScreen> {
+
+  TextEditingController _commandCaptionController = new TextEditingController();
+  TextEditingController _commandMessageController = new TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // This method is rerun every time setState is called
+    return GestureDetector(
+      // dismiss focus (keyboard) if users taps anywhere in a "dead space" within the app
+      // copied from https://flutterigniter.com/dismiss-keyboard-form-lose-focus/
+        onTap: () {
+          FocusScopeNode currentFocus = FocusScope.of(context);
+
+          if (!currentFocus.hasPrimaryFocus) {
+            currentFocus.unfocus();
+          }
+        },
+        child: WillPopScope(
+            onWillPop: _onWillPop,
+            child: Scaffold(
+              appBar: AppBar(
+                title: Text(widget.title),
+              ),
+              body: SingleChildScrollView(
+                child: Builder(
+                  builder: (context) => Padding(
+                      padding: EdgeInsets.fromLTRB(20.0,20.0,20.0,0),
+                      child: Column(
+                          children: <Widget> [
+                            CommandForm(
+                              commandCaptionController: this._commandCaptionController,
+                              commandMessageController: this._commandMessageController
+                            ),
+                            SizedBox(height: 25),
+                          ]
+                      )
+                  ),
+                ),
+              ),
+              floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+              floatingActionButton: FloatingActionButton.extended(
+                  icon: Icon(Icons.add_circle),
+                  onPressed: () => _getProfileIdAndCreateCommand(this._commandCaptionController.text, this._commandMessageController.text, context),
+                  label: new Text('Create Command')
+              ),
+            )
+        )
+    );
+  }
+
+  Future<bool> _onWillPop() async {
+    Map values = {
+      0: _commandCaptionController.text,
+      1: _commandMessageController.text,
+    };
+    if (valuesHaveChanged(values)) {
+      return (await showDialog(
+          context: context,
+          builder: (context) => ConfirmLeaveDialog()
+      )) ?? false;
+    } else {
+      Navigator.of(context).pop(false);
+      return null;
+    }
+  }
+}
+
+_getProfileIdAndCreateCommand(String commandCaption, String commandMessage, BuildContext context) {
+  PreferencesService.getLastProfileId().then((value) => _createCommand(commandCaption, commandMessage, value, context));
+}
+
+_createCommand(String commandCaption, String commandMessage, int profileId, BuildContext context) {
+  Command command = new Command(commandCaption, commandMessage, profileId);
+  DatabaseService.db.insertCommand(command);
+  Navigator.pop(context);
+}

--- a/lib/screens/remote_control/remote_control_screen.dart
+++ b/lib/screens/remote_control/remote_control_screen.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:glutter/widgets/drawer.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:glutter/models/remote_control/command.dart';
+import 'package:glutter/models/shared/profile.dart';
+import 'package:glutter/screens/remote_control/command_create_screen.dart';
 import 'package:glutter/services/remote_control/remote_service.dart';
 import 'package:glutter/services/shared/database_service.dart';
-import 'package:glutter/models/shared/profile.dart';
+import 'package:glutter/widgets/drawer.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 
 class RemoteControlScreen extends StatefulWidget {
     RemoteControlScreen({Key key, this.title: "Remote Control"}) : super(key: key);
@@ -137,9 +138,15 @@ class _RemoteControlState extends State<RemoteControlScreen> {
             ),
             floatingActionButton: FloatingActionButton(
                 child: Icon(Icons.add),
-                onPressed: () async {
-                    Command cmd = new Command("glances -w", "Test for Glances", 1);
-                    await DatabaseService.db.insertCommand(cmd);
+                onPressed: () => {
+                    Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => CommandCreateScreen()),
+                    ).then((value) {
+                        setState(() {
+                            profilesFuture = DatabaseService.db.getProfiles();
+                        });
+                    })
                 }
             ),
         );

--- a/lib/screens/remote_control/remote_control_screen.dart
+++ b/lib/screens/remote_control/remote_control_screen.dart
@@ -5,6 +5,7 @@ import 'package:glutter/services/remote_control/remote_service.dart';
 import 'package:glutter/services/shared/database_service.dart';
 import 'package:glutter/models/shared/profile.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
 
 class RemoteControlScreen extends StatefulWidget {
     RemoteControlScreen({Key key, this.title: "Remote Control"}) : super(key: key);
@@ -83,29 +84,43 @@ class _RemoteControlState extends State<RemoteControlScreen> {
                                                 return new Column (
                                                     mainAxisSize: MainAxisSize.max,
                                                     children: List.generate(snapshot.data.length, (i) {
-                                                        return Card(
-                                                            child: Column(
-                                                                mainAxisSize: MainAxisSize.max,
-                                                                children: <Widget>[
-                                                                    ListTile(
-                                                                        leading: Icon(Icons.comment),
-                                                                        title: Text(snapshot.data[i].caption)
-                                                                    ),
-                                                                    Text(snapshot.data[i].commandMessage),
-                                                                    Padding(
-                                                                        padding: EdgeInsets.fromLTRB(0, 20, 0, 0)
-                                                                    ),
-                                                                    RaisedButton(
-                                                                        child: Text("Execute"),
-                                                                        onPressed: () {
-                                                                            _onPress(snapshot.data[i]);
-                                                                        },
-                                                                    ),
-                                                                    Padding(
-                                                                        padding: EdgeInsets.all(10),
-                                                                    )
-                                                                ],
-                                                            ),
+                                                        return Slidable(
+                                                            actionPane: SlidableDrawerActionPane(),
+                                                            actionExtentRatio: 0.25,
+                                                            actions: <Widget>[
+                                                                IconSlideAction(
+                                                                    caption: 'Delete',
+                                                                    color: Colors.red,
+                                                                    icon: Icons.delete_forever,
+                                                                    onTap: () => _onDelete(snapshot.data[i]),
+                                                                ),
+                                                            ],
+                                                            secondaryActions: [
+                                                                IconSlideAction(
+                                                                    caption: 'Execute',
+                                                                    color: Colors.blue,
+                                                                    icon: Icons.auto_fix_high,
+                                                                    onTap: () => _onPress(snapshot.data[i]),
+                                                                ),
+                                                            ],
+                                                            child: Card(
+                                                                child: Column(
+                                                                    mainAxisSize: MainAxisSize.max,
+                                                                    children: <Widget>[
+                                                                        ListTile(
+                                                                            leading: Icon(Icons.comment),
+                                                                            title: Text(snapshot.data[i].caption)
+                                                                        ),
+                                                                        Text(snapshot.data[i].commandMessage),
+                                                                        Padding(
+                                                                            padding: EdgeInsets.fromLTRB(0, 20, 0, 0)
+                                                                        ),
+                                                                        Padding(
+                                                                            padding: EdgeInsets.all(10),
+                                                                        )
+                                                                    ],
+                                                                ),
+                                                            )
                                                         );
                                                     })
                                                 );
@@ -128,5 +143,10 @@ class _RemoteControlState extends State<RemoteControlScreen> {
                 }
             ),
         );
+    }
+
+    void _onDelete(Command cmd) {
+        DatabaseService.db.deleteCommandById(cmd.id);
+        _onRefresh();
     }
 }

--- a/lib/screens/remote_control/remote_control_screen.dart
+++ b/lib/screens/remote_control/remote_control_screen.dart
@@ -5,6 +5,7 @@ import 'package:glutter/models/shared/profile.dart';
 import 'package:glutter/screens/remote_control/command_create_screen.dart';
 import 'package:glutter/services/remote_control/remote_service.dart';
 import 'package:glutter/services/shared/database_service.dart';
+import 'package:glutter/services/shared/preferences_service.dart';
 import 'package:glutter/widgets/drawer.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
@@ -25,7 +26,12 @@ class _RemoteControlState extends State<RemoteControlScreen> {
     @override
     void initState() {
         this.profilesFuture = DatabaseService.db.getProfiles();
-        this.commandsFuture = DatabaseService.db.getCommands();
+
+        PreferencesService.getLastProfileId().then((value) {
+            this.commandsFuture = DatabaseService.db.getCommandsByProfileId(value);
+            this._onRefresh();
+        });
+
         super.initState();
     }
 
@@ -36,7 +42,9 @@ class _RemoteControlState extends State<RemoteControlScreen> {
         await Future.delayed(Duration(milliseconds: 500));
 
         this.setState(() {
-            this.commandsFuture = DatabaseService.db.getCommands();
+            PreferencesService.getLastProfileId().then((value) {
+                this.commandsFuture = DatabaseService.db.getCommandsByProfileId(value);
+            });
         });
 
         // if failed,use refreshFailed()

--- a/lib/screens/remote_control/widgets/command_form_widgets.dart
+++ b/lib/screens/remote_control/widgets/command_form_widgets.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+class CommandForm extends StatelessWidget {
+  CommandForm({this.commandCaptionController, this.commandMessageController});
+
+  final TextEditingController commandCaptionController;
+  final TextEditingController commandMessageController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: <Widget>[
+      Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Expanded(child: CommandCaptionTextField(commandCaptionController)),
+        ],
+      ),
+      SizedBox(
+        height: 15,
+      ),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.max,
+        children: <Widget>[
+          Expanded(child: CommandMessageTextField(commandMessageController)),
+        ],
+      ),
+    ]);
+  }
+}
+
+class CommandCaptionTextField extends StatelessWidget {
+  CommandCaptionTextField(this.commandCaptionController); // this.context,
+
+  //final BuildContext context;
+  final TextEditingController commandCaptionController;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+        autocorrect: false,
+        controller: commandCaptionController,
+        decoration: InputDecoration(
+          border: OutlineInputBorder(),
+          labelText: 'Caption',
+          hintText: 'e.g. Start glances webserver',
+        ));
+  }
+}
+
+class CommandMessageTextField extends StatelessWidget {
+  CommandMessageTextField(this.commandMessageController);
+
+  final TextEditingController commandMessageController;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+        controller: commandMessageController,
+        decoration: InputDecoration(
+          border: OutlineInputBorder(),
+          labelText: 'Command message',
+          hintText: 'e.g. sudo glances -w',
+        ));
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -132,6 +132,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.3.3"
+  flutter_slidable:
+    dependency: "direct main"
+    description:
+      name: flutter_slidable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.7"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0"
+    version: "12.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.17"
+    version: "0.40.6"
   args:
     dependency: transitive
     description:
@@ -92,13 +92,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -113,6 +106,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0-nullsafety.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   file:
     dependency: transitive
     description:
@@ -131,7 +131,7 @@ packages:
       name: flutter_secure_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.3"
+    version: "3.3.5"
   flutter_slidable:
     dependency: "direct main"
     description:
@@ -156,13 +156,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
   http:
     dependency: "direct main"
     description:
@@ -239,7 +232,7 @@ packages:
       name: node_interop
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   node_io:
     dependency: transitive
     description:
@@ -274,7 +267,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.14"
+    version: "1.6.24"
   path_provider_linux:
     dependency: transitive
     description:
@@ -288,14 +281,21 @@ packages:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+3"
+    version: "0.0.4+6"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4+3"
   pedantic:
     dependency: transitive
     description:
@@ -309,7 +309,7 @@ packages:
       name: percent_indicator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.8"
   platform:
     dependency: transitive
     description:
@@ -317,20 +317,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.1"
-  platform_detect:
-    dependency: transitive
-    description:
-      name: platform_detect
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.4.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   pool:
     dependency: transitive
     description:
@@ -358,28 +351,28 @@ packages:
       name: pull_to_refresh
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.10"
+    version: "0.5.12+4"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2+2"
+    version: "0.0.2+4"
   shared_preferences_macos:
     dependency: transitive
     description:
       name: shared_preferences_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+10"
+    version: "0.0.1+11"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
@@ -394,6 +387,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2+7"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+3"
   shelf:
     dependency: transitive
     description:
@@ -454,7 +454,7 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1+1"
+    version: "1.3.2+1"
   sqflite_common:
     dependency: transitive
     description:
@@ -538,35 +538,42 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.5.3"
+    version: "5.7.10"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+1"
+    version: "0.0.1+4"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+7"
+    version: "0.0.1+9"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3+2"
+    version: "0.1.5+1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+3"
   uuid:
     dependency: transitive
     description:
@@ -587,7 +594,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "5.5.0"
   watcher:
     dependency: transitive
     description:
@@ -608,14 +615,21 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.7.3"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   yaml:
     dependency: transitive
     description:
@@ -624,5 +638,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  dart: ">=2.10.2 <2.11.0"
+  flutter: ">=1.22.2 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
     ssh: any
     flutter_secure_storage: any
     shared_preferences: any
+    flutter_slidable: any
     # process_run: ^0.10.10+1
 
 dev_dependencies:


### PR DESCRIPTION
- RemoteControl-Screen verwendet zentral ausgewähltes Profil und zeigt nur dessen Commands an.
- Slide-Gesten auf den Karten für die Commands implementiert (Löschen und ausführen)
- Screen zum Anlegen eines Commands zum jeweiligen Server ergänzt.