### PR TITLE
Callback-Refresh bei Profile-List und Commands-Screen implementiert

### DIFF
--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -109,14 +109,14 @@ class _DashboardState extends State<DashboardScreen> {
                         if (snapshot.data != null) {
                           return new Container(
                               child: CircularPercentIndicator(
-                                radius: 150.0,
-                                animation: true,
-                                lineWidth: 15.0,
-                                percent: (snapshot.data.totalLoad / 100),
-                                center: new Text(snapshot.data.totalLoad.toString() + "%"),
-                                progressColor: Theme.of(context).accentColor,
-                                backgroundColor: Theme.of(context).primaryColor,
-                              ));
+                            radius: 150.0,
+                            animation: true,
+                            lineWidth: 15.0,
+                            percent: (snapshot.data.totalLoad / 100),
+                            center: new Text(snapshot.data.totalLoad.toString() + "%"),
+                            progressColor: Theme.of(context).accentColor,
+                            backgroundColor: Theme.of(context).primaryColor,
+                          ));
                         }
                         return showNoDataReceived("CPU", this.selectedProfile);
 
@@ -146,14 +146,14 @@ class _DashboardState extends State<DashboardScreen> {
                         if (snapshot.data != null) {
                           return new Center(
                               child: CircularPercentIndicator(
-                                radius: 150.0,
-                                animation: true,
-                                lineWidth: 15.0,
-                                percent: (snapshot.data.usagePercent / 100),
-                                center: new Text(snapshot.data.usagePercent.toString() + "%"),
-                                progressColor: Theme.of(context).accentColor,
-                                backgroundColor: Theme.of(context).primaryColor,
-                              ));
+                            radius: 150.0,
+                            animation: true,
+                            lineWidth: 15.0,
+                            percent: (snapshot.data.usagePercent / 100),
+                            center: new Text(snapshot.data.usagePercent.toString() + "%"),
+                            progressColor: Theme.of(context).accentColor,
+                            backgroundColor: Theme.of(context).primaryColor,
+                          ));
                         }
                         return showNoDataReceived("Memory", this.selectedProfile);
 

--- a/lib/screens/remote_control/remote_control_screen.dart
+++ b/lib/screens/remote_control/remote_control_screen.dart
@@ -136,7 +136,7 @@ class _RemoteControlState extends State<RemoteControlScreen> {
                                             }
                                             return null;
                                         default:
-                                            return Text("default");
+                                            return Text("No commands available for this server");
                                     }
                                 },
                             )
@@ -151,9 +151,7 @@ class _RemoteControlState extends State<RemoteControlScreen> {
                         context,
                         MaterialPageRoute(builder: (context) => CommandCreateScreen()),
                     ).then((value) {
-                        setState(() {
-                            profilesFuture = DatabaseService.db.getProfiles();
-                        });
+                        _onRefresh();
                     })
                 }
             ),

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -16,8 +16,6 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsState extends State<SettingsScreen> {
-  bool _themeBrightnessLight = true;
-
   @override
   void initState() {
     super.initState();

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -57,7 +57,7 @@ class AppDrawer extends StatelessWidget {
                 _createDrawerItem(
                     icon: Icons.bug_report,
                     text: 'Report an issue',
-                    onTap: () => launchURL("https://github.com/HeLau1337/glutter/issues/new/choose")),
+                    onTap: () => launchURL("https://github.com/glutter-dev-team/glutter/issues/new")),
                 ListTile(
                   title: Text('v0.0.1'),
                   onTap: () {},

--- a/lib/widgets/profile_selector.dart
+++ b/lib/widgets/profile_selector.dart
@@ -36,21 +36,27 @@ class _ProfileSelectorState extends State<ProfileSelector> {
                 return Center(child: Container(child: new CircularProgressIndicator(), alignment: Alignment(0.0, 0.0)));
               case ConnectionState.done:
                 return new Container(
-                    child: DropdownButton<Profile>(
-                  items: snapshot.data
-                      .map((Profile item) {
-                        return DropdownMenuItem<Profile>(value: item, child: Text(item.caption + " (" + item.serverAddress + ")"));
-                      })
-                      .cast<DropdownMenuItem<Profile>>()
-                      .toList(),
-                  onChanged: (Profile newSelectedProfile) {
-                    setState(() {
-                      selectedProfile = newSelectedProfile;
-                      PreferencesService.setLastProfileId(newSelectedProfile.id);
-                    });
-                  },
-                  value: selectedProfile,
-                ));
+                    width: 200,
+                    height: 60,
+                    child: DropdownButtonHideUnderline(
+                      child: DropdownButton<Profile>(
+                      isExpanded: true,
+                      items: snapshot.data
+                          .map((Profile item) {
+                            return DropdownMenuItem<Profile>(value: item, child: Text(item.caption + " (" + item.serverAddress + ")"));
+                          })
+                          .cast<DropdownMenuItem<Profile>>()
+                          .toList(),
+                      onChanged: (Profile newSelectedProfile) {
+                        setState(() {
+                          selectedProfile = newSelectedProfile;
+                          PreferencesService.setLastProfileId(newSelectedProfile.id);
+                        });
+                      },
+                      value: selectedProfile,
+                    )
+                )
+            );
               default:
                 return Text("default");
             }

--- a/test/glances_service_test.dart
+++ b/test/glances_service_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 void main() {
   /// Test-Constant "TestServer" -> Add your connection-values here!
-  final Profile testServer = new Profile('INSERT_ADDRESS_HERE', 61208, '2', 'Testserver', 22, 'admin');
+  final Profile testServer = new Profile('seafileserver', 61208, '2', 'Testserver', 22, 'admin');
 
   /// Test-Constant "service", generated from the TestServer-Constant.
   final GlancesService service = new GlancesService(testServer);


### PR DESCRIPTION
Die Seiten aktualisieren sich über die _onRefresh() Methode, wenn man von einer anderen Seite darauf zurücknavigiert. Fix #62 